### PR TITLE
chore: delete default d-rating badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 UI for data collection app to measure proportion of urban population living in slums, informal settlements or inadequate housing
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/f900bb0c061e480fa1888a40dd25925b)](https://app.codacy.com/gh/BuildForSDG/Team-269-Frontend?utm_source=github.com&utm_medium=referral&utm_content=BuildForSDG/Team-269-Frontend&utm_campaign=Badge_Grade_Settings)
-[![Codacy Badge](https://img.shields.io/badge/Code%20Quality-D-red)](https://img.shields.io/badge/Code%20Quality-D-red)
 
 
 ## About


### PR DESCRIPTION
## Description
Please include a summary of the change and relevant motivation and context. 
Basically deletes the redundant default badge with D-rating from the front-end readme

Fixes #(  Issue #14) [https://github.com/BuildForSDG/Team-269-Frontend/issues/14](link)

## How Has This Been Tested?
It's a delete so it can be seen visibly by the D-Badge disappearing on the current branch.

## Screenshots 
Front end Readme was having two badges before this PR
![Screenshot from 2020-05-20 10-46-03](https://user-images.githubusercontent.com/36065782/82419487-2c236100-9a87-11ea-8c31-519d3877f040.png)


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [x ] New and existing unit tests pass locally with my changes
